### PR TITLE
Add check for c$http$method before accessing

### DIFF
--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -10,7 +10,7 @@ redef enum Notice::Type += {
 # Check HTTP GET Request for BODY
 event http_entity_data(c: connection, is_orig: bool, length: count, data: string)
 {
-    if (is_orig && c$http$method == "GET")
+    if (is_orig && c$http?$method && c$http$method == "GET")
         NOTICE([$note=HTTP_Smuggling,
         $msg="HTTP GET request with body detected",
         $conn = c]);


### PR DESCRIPTION
In some environments, I have seen HTTP traffic that drops into `http_entity_data` but `$method` isn't set, so it throws errors in reporter.log
This change adds a check to make sure `c$http$method` is set before accessing `c$http$method`, so that it can drop out gracefully if it's not there.